### PR TITLE
Add `vue-template-compiler` to devDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "eslint-plugin-standard": "^3.0.1",
     "eslint-plugin-vue": "^4.3.0",
     "quasar-cli": "^0.17.22",
-    "strip-ansi": "=3.0.1"
+    "strip-ansi": "=3.0.1",
+    "vue-template-compiler": "^2.6.10"
   },
   "engines": {
     "node": ">= 8.9.0",


### PR DESCRIPTION
While yarn automatically installs peer dependencies, npm does not. More discussion here: https://github.com/vuejs/vue-loader/issues/560

`npm i -D vue-template-compiler`

This adds an explicit dev dependency to go with the electron dev dependencies. So, npm users can clone this repo, run npm ci and npm run dev, and have a working example.

Closes #1 